### PR TITLE
📱  add iPad support

### DIFF
--- a/PGPro.xcodeproj/project.pbxproj
+++ b/PGPro.xcodeproj/project.pbxproj
@@ -93,9 +93,9 @@
 
 /* Begin PBXFileReference section */
 		810AE9D4248D421400DF17D2 /* UIView+pinEdges.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+pinEdges.swift"; sourceTree = "<group>"; };
-		810C4C5426429AEE00A5064D /* 3.asc */ = {isa = PBXFileReference; lastKnownFileType = file; name = 3.asc; path = PGProTests/Keys/3.asc; sourceTree = SOURCE_ROOT; };
-		810C4C562642A0A100A5064D /* 5.asc */ = {isa = PBXFileReference; lastKnownFileType = file; name = 5.asc; path = PGProTests/Keys/5.asc; sourceTree = SOURCE_ROOT; };
-		810C4C572642A0A100A5064D /* 4.asc */ = {isa = PBXFileReference; lastKnownFileType = file; name = 4.asc; path = PGProTests/Keys/4.asc; sourceTree = SOURCE_ROOT; };
+		810C4C5426429AEE00A5064D /* 3.asc */ = {isa = PBXFileReference; lastKnownFileType = text; name = 3.asc; path = PGProTests/Keys/3.asc; sourceTree = SOURCE_ROOT; };
+		810C4C562642A0A100A5064D /* 5.asc */ = {isa = PBXFileReference; lastKnownFileType = text; name = 5.asc; path = PGProTests/Keys/5.asc; sourceTree = SOURCE_ROOT; };
+		810C4C572642A0A100A5064D /* 4.asc */ = {isa = PBXFileReference; lastKnownFileType = text; name = 4.asc; path = PGProTests/Keys/4.asc; sourceTree = SOURCE_ROOT; };
 		8114B89F2315B664001DBAC5 /* KeychainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainViewController.swift; sourceTree = "<group>"; };
 		8114B8A3231815D5001DBAC5 /* EncryptionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptionViewController.swift; sourceTree = "<group>"; };
 		8114B8A5231822D9001DBAC5 /* KeychainTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainTableViewCell.swift; sourceTree = "<group>"; };
@@ -966,7 +966,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -993,7 +993,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = app.pgpro;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Enabled iPad option in XCode project preferences so that PGPro can have the full power on iPadOS.
Closes #38.

## preview
### before

![IMG_A83C706A3028-1](https://user-images.githubusercontent.com/47633893/117144620-6bd77b80-adb2-11eb-835c-9f037d92027f.jpeg)


### after
![IMG_D76C10AF2A9E-1](https://user-images.githubusercontent.com/47633893/117143118-c243ba80-adb0-11eb-9ee4-1b18e213ba18.jpeg)

![IMG_91644E9DF231-1](https://user-images.githubusercontent.com/47633893/117143173-d7204e00-adb0-11eb-88cf-38eac3f53f78.jpeg)

![IMG_CC7807783B31-1](https://user-images.githubusercontent.com/47633893/117143510-34b49a80-adb1-11eb-99bd-d18fb1d37a03.jpeg)



https://user-images.githubusercontent.com/47633893/117143919-a2f95d00-adb1-11eb-9280-afd6ed797966.mov

